### PR TITLE
Enhance CI workflow for testing and building

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,9 +7,32 @@ on:
     branches: [main]
 
 jobs:
-  test:
-    name: Test
+  test-and-build:
+    name: 🧪 Run Jest & Cypress
     runs-on: ubuntu-latest
+
     steps:
-      - uses: actions/checkout@v3
-      - run: echo "✅ Hello, CI is running!"
+      - name: 📥 Checkout code
+        uses: actions/checkout@v3
+
+      - name: 🟢 Setup Node.js with pnpm
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: 'pnpm'
+
+      - name: 📦 Install dependencies
+        run: |
+          corepack enable
+          pnpm install
+
+      - name: 🧪 Run Jest tests
+        run: pnpm test
+
+      - name: 🧪 Run Cypress tests
+        uses: cypress-io/github-action@v6
+        with:
+          build: pnpm build # Cypress builds the app
+          start: pnpm start # Starts local server
+          wait-on: 'http://localhost:3000'
+          wait-on-timeout: 60

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,16 +15,16 @@ jobs:
       - name: 📥 Checkout code
         uses: actions/checkout@v3
 
+      - name: 🟢 Setup pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: 8
+
       - name: 🟢 Setup Node.js
         uses: actions/setup-node@v3
         with:
           node-version: 18
           cache: 'pnpm'
-
-      - name: 🟢 Setup pnpm
-        uses: pnpm/action-setup@v2
-        with:
-          version: 8
 
       - name: 📦 Install dependencies
         run: pnpm install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,16 +15,19 @@ jobs:
       - name: 📥 Checkout code
         uses: actions/checkout@v3
 
-      - name: 🟢 Setup Node.js with pnpm
+      - name: 🟢 Setup Node.js
         uses: actions/setup-node@v3
         with:
           node-version: 18
           cache: 'pnpm'
 
+      - name: 🟢 Setup pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: 8
+
       - name: 📦 Install dependencies
-        run: |
-          corepack enable
-          pnpm install
+        run: pnpm install
 
       - name: 🧪 Run Jest tests
         run: pnpm test
@@ -32,7 +35,7 @@ jobs:
       - name: 🧪 Run Cypress tests
         uses: cypress-io/github-action@v6
         with:
-          build: pnpm build # Cypress builds the app
-          start: pnpm start # Starts local server
+          build: pnpm build
+          start: pnpm start
           wait-on: 'http://localhost:3000'
           wait-on-timeout: 60


### PR DESCRIPTION
- Renamed the CI job to `test-and-build` for better clarity.
- Added steps to set up Node.js with pnpm, install dependencies, and run Jest and Cypress tests.
- Improved the workflow to include a local server start and wait for the application before running Cypress tests.